### PR TITLE
README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,17 @@ We use the pattern of picking settings per environment. You will want to use the
 
 For security passwords aren't kept in the repository and will need to be added to your virtual environment. There are a few ways to do this but an easy way is as follows:
 
+For Linux:
+
 
     # one-off basic environment setup
     echo 'export GUILD_DJANGO_SECRET_KEY='$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1) >> $VIRTUAL_ENV/bin/postactivate
 
-
+For Windows (elevated Powershell window):
+    
+    
+    #Set GUILD_DJANGO_SECRET_KEY as a machine level environment variable
+    [Environment]::SetEnvironmentVariable("GUILD_DJANGO_SECRET_KEY", "secretkeygoeshere", "Machine")
 
 #### 3. Run, run, run
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ We use the pattern of picking settings per environment. You will want to use the
     ln -s development.py __init__.py
     
     # Windows
-    mklink development.py __init__.py
+    mklink /d __init__.py development.py
     
     cd ../..
 


### PR DESCRIPTION
I made some updates to the readme based on my discoveries while setting up the dev environment on my Windows 10 machine. 

- Had some trouble with the mklink command for symbolic linking the development.py and \_\_init\_\_.py files in projects/system, turns out that the syntax is backwards from Linux so that your link is first (\_\_init\_\_.py), then the target (development.py)
- Adding an environment variable via Powershell (more [here](https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-powershell-1.0/ff730964(v=technet.10))). Syntax is pretty straightforward, though I haven't added any code to generate the key like for the Linux instructions, but you could make your own key-phrase in a generator and copy it in.