### PR TITLE
Fix modification of booking date upon saving a booking object

### DIFF
--- a/project/bookings/models.py
+++ b/project/bookings/models.py
@@ -245,8 +245,8 @@ class Booking(models.Model):
         if not self.status == 'no_show' and self.is_cancelled:
             self.is_cancelled = False
 
+        super(Booking, self).save(*args, **kwargs)
+
         booking_date, is_created = BookingDate.objects.get_or_create(
             date=self.reserved_date)
         booking_date.set_values()
-
-        super(Booking, self).save(*args, **kwargs)


### PR DESCRIPTION
After a Booking object is created, the corresponding BookingDate object must be modified to contain the
new information (how many more people are expected etc). Previously, the BookingDate object was being updated before the new information was written to the database (The Booking object saved) leading to Issue #46.

This has now been fixed by calling the super classes method before updating the BookingDate object.