### PR TITLE
Removed notes widget from BookingAdminForm

### DIFF
--- a/project/bookings/forms.py
+++ b/project/bookings/forms.py
@@ -13,8 +13,6 @@ class BookingAdminForm(forms.ModelForm):
     class Meta(object):
         fields = ['name', 'site', 'reserved_date', 'reserved_time']
         model = Booking
-        widgets = {'notes': TinyMCE()}
-
 
 class BookingForm(forms.ModelForm):
     required_css_class = 'required'


### PR DESCRIPTION
There is no control over the html of the notes when first creating a booking, so this extra control has been removed from the BookingAdminForm as it is unnecessary.