### PR TITLE
Fixed reserved_time loading incorrect value and defaulting to 12:00

### DIFF
--- a/project/bookings/settings.py
+++ b/project/bookings/settings.py
@@ -74,9 +74,14 @@ def generate_times():
     temp_date, time_list = datetime.date(2000, 1, 1), []
     this_time = BOOKING_TIMES[0]
     while this_time <= BOOKING_TIMES[1]:
-        this_time_formatted = "{}:{:0>2}".format(
+        
+        # Choice fields values need the seconds portion, but this
+        # is omitted for the displayed time
+        
+        this_time_display_label = "{}:{:0>2}".format(
             this_time.hour, this_time.minute)
-        time_list.append((this_time_formatted, this_time_formatted))
+        this_time_actual_value = this_time_display_label + ":00"    
+        time_list.append((this_time_actual_value, this_time_display_label))
 
         # hack around timedelta not allowing time addition (on purpose)
         # http://bugs.python.org/issue1487389

--- a/project/bookings/views.py
+++ b/project/bookings/views.py
@@ -186,9 +186,9 @@ Link to day: http://guild.house/bookings/{url_day}
                    url=obj.get_absolute_url(),
                    method=form.cleaned_data.get('booking_method'),
                    day=form.cleaned_data.get('reserved_date').strftime('%a'),
-                   time=form.cleaned_data.get('reserved_time'),
+                   time=str(form.cleaned_data.get('reserved_time')),
                    date=form.cleaned_data.get(
-                       'reserved_date').strftime('%-d-%b-%Y'),
+                       'reserved_date').strftime('%d-%b-%Y'),
                    url_day=form.cleaned_data.get(
                        'reserved_date').strftime('%Y/%m/%d/'),
                    pax=form.cleaned_data.get('party_size'),
@@ -196,7 +196,7 @@ Link to day: http://guild.house/bookings/{url_day}
                    )
         subject = "[{method}] {name} {pax}pax {date} ".format(
             method=form.cleaned_data.get('booking_method'),
-            date=form.cleaned_data.get('reserved_date').strftime('%a %-d-%b'),
+            date=form.cleaned_data.get('reserved_date').strftime('%a %d-%b'),
             pax=form.cleaned_data.get('party_size'),
             name=form.cleaned_data.get('name')
         )
@@ -243,15 +243,15 @@ Open 7 days, 12pm til late
                    url=obj.get_absolute_url(),
                    method=form.cleaned_data.get('booking_method'),
                    day=form.cleaned_data.get('reserved_date').strftime('%a'),
-                   time=form.cleaned_data.get('reserved_time'),
+                   time=str(form.cleaned_data.get('reserved_time')),
                    date=form.cleaned_data.get(
-                       'reserved_date').strftime('%-d-%b-%Y'),
+                       'reserved_date').strftime('%d-%b-%Y'),
                    pax=form.cleaned_data.get('party_size'),
                    name=form.cleaned_data.get('name'),
                    )
         subject = "[{method}] {name} {pax}pax {date} ".format(
             method=form.cleaned_data.get('booking_method'),
-            date=form.cleaned_data.get('reserved_date').strftime('%a %-d-%b'),
+            date=form.cleaned_data.get('reserved_date').strftime('%a %d-%b'),
             pax=form.cleaned_data.get('party_size'),
             name=form.cleaned_data.get('name')
         )


### PR DESCRIPTION
Fix relating to issue #49  where the reserved time field does not load up the correct value based on the booking.

The reserved_time field saves the time with seconds appended so adding seconds to the drop down makes the values match so the right option gets selected. The label was changed so that the seconds don't appear to the user.

Also found that "%-d" was an invalid format string, so I replaced it with the equivalent "%d" (,aybe it's a Windows thing?)