### PR TITLE
Remove service field from admin add booking form

### DIFF
--- a/project/bookings/admin.py
+++ b/project/bookings/admin.py
@@ -21,7 +21,7 @@ class BookingAdmin(admin.ModelAdmin):
     fieldsets = [
         ('Content', {'fields': ['reserved_date', 'reserved_time',
                                 'booking_duration', 'name', 'party_size',
-                                'status', 'is_cancelled', 'service', 'email',
+                                'status', 'is_cancelled', 'email',
                                 'phone', 'notes', 'private_notes']}),
         ('Publishing', {'fields': ['site', ('created_at', 'updated_at')],
                         'classes': ['collapse']}),


### PR DESCRIPTION
This PR resolves #42 - Selected service is overridden by reserved time. 

The decided action was to remove the 'Service' field from the admin "Add Booking" form. This prevents the admin user from attempting to a select a value that will be overwritten/generated by the given booking time.

The 'Service' _value_ is still generated by the booking time and is still presented when viewing the booking. 

